### PR TITLE
catalog in get_table_names adjusted with backquotes

### DIFF
--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -246,11 +246,13 @@ class DatabricksDialect(default.DefaultDialect):
 
     def get_table_names(self, connection, schema=None, **kwargs):
         TABLE_NAME = 1
+        catalog = "`" + self.catalog + "`"
+
         with self.get_driver_connection(
             connection
         )._dbapi_connection.dbapi_connection.cursor() as cur:
             sql_str = "SHOW TABLES FROM {}".format(
-                ".".join([self.catalog, schema or self.schema])
+                ".".join([catalog, schema or self.schema])
             )
             data = cur.execute(sql_str).fetchall()
             _tables = [i[TABLE_NAME] for i in data]


### PR DESCRIPTION
Backquotes added to catalog name to prevent SQL syntax error when fetching metadata in get tables.